### PR TITLE
Fix (ckeditor5-core): check command existence in multicommand execute

### DIFF
--- a/packages/ckeditor5-core/src/multicommand.js
+++ b/packages/ckeditor5-core/src/multicommand.js
@@ -63,7 +63,7 @@ export default class MultiCommand extends Command {
 	execute( ...args ) {
 		const command = this._getFirstEnabledCommand();
 
-		return command.execute( args );
+		return command != null && command.execute( args );
 	}
 
 	/**


### PR DESCRIPTION
`_getFirstEnabledCommand` may return `undefined`, but `execute` does not check if returned value is defined.


### Additional information

Not encountered as a bug, but found will creating Typescript typings.
